### PR TITLE
Correct command for adding netdata user to adm group

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a simple module for [Netdata](https://github.com/firehol/netdata) to add
 2. Run update.sh to install or update module to netdata root
 
 3. Make sure the /var/log/auth.log is readable for the user netdata, e.g. by 
-   chgrp -G adm netdata
+   usermod -G adm netdata
 
 4. Control if the module is working by running as user netdata:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a simple module for [Netdata](https://github.com/firehol/netdata) to add
 2. Run update.sh to install or update module to netdata root
 
 3. Make sure the /var/log/auth.log is readable for the user netdata, e.g. by 
-   usermod -G adm netdata
+   usermod -aG adm netdata
 
 4. Control if the module is working by running as user netdata:
 


### PR DESCRIPTION
The correct command to add a user to a group is `usermod -G`. `chgrp` would change the owner of the file. Guess that was just a typo, since `chgrp` has no `-G` flag :)